### PR TITLE
Added hurt/hitboxes. Facing now determine in new Main_Game.gd.

### DIFF
--- a/Fighter.gd
+++ b/Fighter.gd
@@ -5,11 +5,10 @@ export var DASH_SPEED = 500
 export var player_number : int
 var movement = Vector2.ZERO #2D Vector
 var control_inputs = {}
-var facing = "right"
+export var facing_right = true
 onready var anim = $AnimationPlayer
 onready var sprite = $Sprite
-onready var left_ray = $LeftRayCast
-onready var right_ray = $RightRayCast
+onready var this_name = self.name
 
 enum STATE {ATTACK, GUARD, FREE}
 var state
@@ -20,7 +19,6 @@ func _ready():
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(delta):
-	look_direction()
 	player_input()
 	animates_player()
 	movement = move_and_slide(movement)
@@ -29,7 +27,7 @@ func _process(delta):
 func animates_player():
 	if state == STATE.FREE:
 		if movement != Vector2.ZERO:
-			if (facing == "left" && control_inputs.left) || (facing == "right" && control_inputs.right):
+			if (!facing_right && control_inputs.left) || (facing_right && control_inputs.right):
 				anim.play("walk")
 			else:
 				anim.play_backwards("walk")
@@ -56,13 +54,9 @@ func animates_player():
 			
 
 # Allows us to generalize characters and not worry about sprite facing.
-func look_direction():
-	if left_ray.is_colliding() && facing != "left":
-		sprite.flip_h = true
-		facing = "left"
-	if right_ray.is_colliding() && facing != "right":
-		sprite.flip_h = true
-		facing = "right"
+func change_direction():
+	scale.x = -1
+	facing_right = !facing_right
 
 
 # To share the same code for each player we have this function to determine
@@ -89,7 +83,14 @@ func player_input():
 			}
 		_:
 			print("No player number entered. You sure you're in the right scene?")
-			return
+			control_inputs = {
+				"left": Input.is_action_pressed("p1_left"),
+				"right": Input.is_action_pressed("p1_right"),
+				"punch": Input.is_action_just_pressed("p1_punch"),
+				"kick": Input.is_action_just_pressed("p1_kick"),
+				"block": Input.is_action_pressed("p1_block"),
+				"block_release": Input.is_action_just_released("p1_block")
+			}
 	player_movement()
 
 func player_movement():
@@ -104,3 +105,25 @@ func player_movement():
 			movement.x = 0
 	else:
 		movement.x = 0
+
+
+func _on_PunchHitBox_area_entered(area: Area2D) -> void:
+	if area.get_parent().name == this_name:
+		return
+	if area.name == "BlockBox":
+		print("Hit Block")
+	if area.name == "HurtBox":
+		print("Hit Character")
+	if area.name == "PunchHitBox":
+		print("clank")
+
+
+func _on_KickHitBox_area_entered(area: Area2D) -> void:
+	if area.get_parent().name == this_name:
+		return
+	if area.name == "BlockHitBox":
+		print("Hit Block")
+	if area.name == "HurtBox":
+		print("Hit Character")
+	if area.name == "KickHitBox":
+		print("clank")

--- a/Fighter.gd
+++ b/Fighter.gd
@@ -51,12 +51,6 @@ func animates_player():
 		if control_inputs.block_release:
 			anim.play("idle")
 			state = STATE.FREE
-			
-
-# Allows us to generalize characters and not worry about sprite facing.
-func change_direction():
-	scale.x = -1
-	facing_right = !facing_right
 
 
 # To share the same code for each player we have this function to determine

--- a/Fighter.tscn
+++ b/Fighter.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=25 format=2]
+[gd_scene load_steps=30 format=2]
 
 [ext_resource path="res://Fighter.gd" type="Script" id=1]
 [ext_resource path="res://assets/character/SubZero/001.png" type="Texture" id=2]
@@ -51,6 +51,54 @@ tracks/0/keys = {
 "update": 1,
 "values": [ ExtResource( 16 ) ]
 }
+tracks/1/type = "value"
+tracks/1/path = NodePath("Sprite:position")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/keys = {
+"times": PoolRealArray( 0 ),
+"transitions": PoolRealArray( 1 ),
+"update": 1,
+"values": [ Vector2( 0, 0 ) ]
+}
+tracks/2/type = "value"
+tracks/2/path = NodePath("HurtBox:monitorable")
+tracks/2/interp = 1
+tracks/2/loop_wrap = true
+tracks/2/imported = false
+tracks/2/enabled = true
+tracks/2/keys = {
+"times": PoolRealArray( 0 ),
+"transitions": PoolRealArray( 1 ),
+"update": 1,
+"values": [ false ]
+}
+tracks/3/type = "value"
+tracks/3/path = NodePath("BlockHitBox:monitorable")
+tracks/3/interp = 1
+tracks/3/loop_wrap = true
+tracks/3/imported = false
+tracks/3/enabled = true
+tracks/3/keys = {
+"times": PoolRealArray( 0 ),
+"transitions": PoolRealArray( 1 ),
+"update": 1,
+"values": [ true ]
+}
+tracks/4/type = "value"
+tracks/4/path = NodePath("BlockBox:monitorable")
+tracks/4/interp = 1
+tracks/4/loop_wrap = true
+tracks/4/imported = false
+tracks/4/enabled = true
+tracks/4/keys = {
+"times": PoolRealArray( 0 ),
+"transitions": PoolRealArray( 1 ),
+"update": 1,
+"values": [ true ]
+}
 
 [sub_resource type="Animation" id=5]
 loop = true
@@ -67,9 +115,56 @@ tracks/0/keys = {
 "update": 1,
 "values": [ ExtResource( 2 ), ExtResource( 2 ), ExtResource( 9 ), ExtResource( 10 ), ExtResource( 9 ) ]
 }
+tracks/1/type = "value"
+tracks/1/path = NodePath("Sprite:position")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/keys = {
+"times": PoolRealArray( 0, 0.25 ),
+"transitions": PoolRealArray( 1, 1 ),
+"update": 1,
+"values": [ Vector2( -0.5, 0 ), Vector2( 0, 0 ) ]
+}
+tracks/2/type = "value"
+tracks/2/path = NodePath("HurtBox:monitorable")
+tracks/2/interp = 1
+tracks/2/loop_wrap = true
+tracks/2/imported = false
+tracks/2/enabled = true
+tracks/2/keys = {
+"times": PoolRealArray( 0 ),
+"transitions": PoolRealArray( 1 ),
+"update": 1,
+"values": [ true ]
+}
+tracks/3/type = "value"
+tracks/3/path = NodePath("BlockHitBox:monitorable")
+tracks/3/interp = 1
+tracks/3/loop_wrap = true
+tracks/3/imported = false
+tracks/3/enabled = true
+tracks/3/keys = {
+"times": PoolRealArray( 0 ),
+"transitions": PoolRealArray( 1 ),
+"update": 1,
+"values": [ false ]
+}
+tracks/4/type = "value"
+tracks/4/path = NodePath("BlockBox:monitorable")
+tracks/4/interp = 1
+tracks/4/loop_wrap = true
+tracks/4/imported = false
+tracks/4/enabled = true
+tracks/4/keys = {
+"times": PoolRealArray( 0 ),
+"transitions": PoolRealArray( 1 ),
+"update": 1,
+"values": [ false ]
+}
 
 [sub_resource type="Animation" id=6]
-length = 0.3
 tracks/0/type = "value"
 tracks/0/path = NodePath("Sprite:texture")
 tracks/0/interp = 1
@@ -81,6 +176,66 @@ tracks/0/keys = {
 "transitions": PoolRealArray( 1, 1, 1 ),
 "update": 1,
 "values": [ ExtResource( 3 ), ExtResource( 8 ), ExtResource( 7 ) ]
+}
+tracks/1/type = "value"
+tracks/1/path = NodePath("Sprite:position")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/keys = {
+"times": PoolRealArray( 0, 0.1, 0.2, 0.3 ),
+"transitions": PoolRealArray( 1, 1, 1, 1 ),
+"update": 1,
+"values": [ Vector2( 7.54016, 14.2866 ), Vector2( 17.263, 26.9858 ), Vector2( 36.5103, 34.9229 ), Vector2( 36.51, 34.923 ) ]
+}
+tracks/2/type = "value"
+tracks/2/path = NodePath("HurtBox:monitorable")
+tracks/2/interp = 1
+tracks/2/loop_wrap = true
+tracks/2/imported = false
+tracks/2/enabled = true
+tracks/2/keys = {
+"times": PoolRealArray( 0 ),
+"transitions": PoolRealArray( 1 ),
+"update": 1,
+"values": [ true ]
+}
+tracks/3/type = "value"
+tracks/3/path = NodePath("BlockHitBox:monitorable")
+tracks/3/interp = 1
+tracks/3/loop_wrap = true
+tracks/3/imported = false
+tracks/3/enabled = true
+tracks/3/keys = {
+"times": PoolRealArray( 0 ),
+"transitions": PoolRealArray( 1 ),
+"update": 1,
+"values": [ false ]
+}
+tracks/4/type = "value"
+tracks/4/path = NodePath("BlockBox:monitorable")
+tracks/4/interp = 1
+tracks/4/loop_wrap = true
+tracks/4/imported = false
+tracks/4/enabled = true
+tracks/4/keys = {
+"times": PoolRealArray( 0 ),
+"transitions": PoolRealArray( 1 ),
+"update": 1,
+"values": [ false ]
+}
+tracks/5/type = "value"
+tracks/5/path = NodePath("KickHitBox/CollisionShape2D:disabled")
+tracks/5/interp = 1
+tracks/5/loop_wrap = true
+tracks/5/imported = false
+tracks/5/enabled = true
+tracks/5/keys = {
+"times": PoolRealArray( 0, 0.2, 0.3 ),
+"transitions": PoolRealArray( 1, 1, 1 ),
+"update": 1,
+"values": [ true, false, true ]
 }
 
 [sub_resource type="Animation" id=7]
@@ -96,6 +251,66 @@ tracks/0/keys = {
 "transitions": PoolRealArray( 1, 1 ),
 "update": 1,
 "values": [ ExtResource( 15 ), ExtResource( 14 ) ]
+}
+tracks/1/type = "value"
+tracks/1/path = NodePath("Sprite:position")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/keys = {
+"times": PoolRealArray( 0, 0.1 ),
+"transitions": PoolRealArray( 1, 1 ),
+"update": 1,
+"values": [ Vector2( 10.5159, 0.547794 ), Vector2( 20.106, 1.56426 ) ]
+}
+tracks/2/type = "value"
+tracks/2/path = NodePath("PunchHitBox/CollisionShape2D:disabled")
+tracks/2/interp = 1
+tracks/2/loop_wrap = true
+tracks/2/imported = false
+tracks/2/enabled = true
+tracks/2/keys = {
+"times": PoolRealArray( 0, 0.1, 0.2 ),
+"transitions": PoolRealArray( 1, 1, 1 ),
+"update": 1,
+"values": [ true, false, true ]
+}
+tracks/3/type = "value"
+tracks/3/path = NodePath("HurtBox:monitorable")
+tracks/3/interp = 1
+tracks/3/loop_wrap = true
+tracks/3/imported = false
+tracks/3/enabled = true
+tracks/3/keys = {
+"times": PoolRealArray( 0 ),
+"transitions": PoolRealArray( 1 ),
+"update": 1,
+"values": [ true ]
+}
+tracks/4/type = "value"
+tracks/4/path = NodePath("BlockHitBox:monitorable")
+tracks/4/interp = 1
+tracks/4/loop_wrap = true
+tracks/4/imported = false
+tracks/4/enabled = true
+tracks/4/keys = {
+"times": PoolRealArray( 0 ),
+"transitions": PoolRealArray( 1 ),
+"update": 1,
+"values": [ false ]
+}
+tracks/5/type = "value"
+tracks/5/path = NodePath("BlockBox:monitorable")
+tracks/5/interp = 1
+tracks/5/loop_wrap = true
+tracks/5/imported = false
+tracks/5/enabled = true
+tracks/5/keys = {
+"times": PoolRealArray( 0 ),
+"transitions": PoolRealArray( 1 ),
+"update": 1,
+"values": [ false ]
 }
 
 [sub_resource type="Animation" id=8]
@@ -113,15 +328,83 @@ tracks/0/keys = {
 "update": 1,
 "values": [ ExtResource( 6 ), ExtResource( 13 ), ExtResource( 4 ), ExtResource( 11 ), ExtResource( 12 ), ExtResource( 5 ) ]
 }
+tracks/1/type = "value"
+tracks/1/path = NodePath("Sprite:position")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/keys = {
+"times": PoolRealArray( 0 ),
+"transitions": PoolRealArray( 1 ),
+"update": 0,
+"values": [ Vector2( 0, 0 ) ]
+}
+tracks/2/type = "value"
+tracks/2/path = NodePath("HurtBox:monitorable")
+tracks/2/interp = 1
+tracks/2/loop_wrap = true
+tracks/2/imported = false
+tracks/2/enabled = true
+tracks/2/keys = {
+"times": PoolRealArray( 0 ),
+"transitions": PoolRealArray( 1 ),
+"update": 1,
+"values": [ true ]
+}
+tracks/3/type = "value"
+tracks/3/path = NodePath("BlockHitBox:monitorable")
+tracks/3/interp = 1
+tracks/3/loop_wrap = true
+tracks/3/imported = false
+tracks/3/enabled = true
+tracks/3/keys = {
+"times": PoolRealArray( 0 ),
+"transitions": PoolRealArray( 1 ),
+"update": 1,
+"values": [ false ]
+}
+tracks/4/type = "value"
+tracks/4/path = NodePath("BlockBox:monitorable")
+tracks/4/interp = 1
+tracks/4/loop_wrap = true
+tracks/4/imported = false
+tracks/4/enabled = true
+tracks/4/keys = {
+"times": PoolRealArray( 0 ),
+"transitions": PoolRealArray( 1 ),
+"update": 1,
+"values": [ false ]
+}
 
-[node name="Fighter" type="KinematicBody2D"]
+[sub_resource type="RectangleShape2D" id=9]
+extents = Vector2( 27.9225, 10 )
+
+[sub_resource type="RectangleShape2D" id=10]
+extents = Vector2( 25.918, 55.8375 )
+
+[sub_resource type="RectangleShape2D" id=11]
+extents = Vector2( 25.4726, 25.3243 )
+
+[sub_resource type="RectangleShape2D" id=12]
+extents = Vector2( 25.4726, 24.2106 )
+
+[sub_resource type="RectangleShape2D" id=13]
+extents = Vector2( 37.4997, 19.9789 )
+
+[node name="Fighter" type="KinematicBody2D" groups=[
+"Characters",
+]]
+collision_layer = 513
 script = ExtResource( 1 )
 
 [node name="Sprite" type="Sprite" parent="."]
 material = SubResource( 2 )
-texture = ExtResource( 9 )
+position = Vector2( 36.51, 34.923 )
+texture = ExtResource( 7 )
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+[node name="Body" type="CollisionShape2D" parent="."]
+modulate = Color( 0.372549, 0.960784, 0.94902, 1 )
 shape = SubResource( 3 )
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]
@@ -131,10 +414,41 @@ anims/kick = SubResource( 6 )
 anims/punch = SubResource( 7 )
 anims/walk = SubResource( 8 )
 
-[node name="RightRayCast" type="RayCast2D" parent="."]
-enabled = true
-cast_to = Vector2( 10000, 0 )
+[node name="PunchHitBox" type="Area2D" parent="."]
 
-[node name="LeftRayCast" type="RayCast2D" parent="."]
-enabled = true
-cast_to = Vector2( -10000, 0 )
+[node name="CollisionShape2D" type="CollisionShape2D" parent="PunchHitBox"]
+modulate = Color( 0.996078, 0.282353, 0.282353, 1 )
+position = Vector2( 40.5359, -31.6269 )
+shape = SubResource( 9 )
+disabled = true
+
+[node name="HurtBox" type="Area2D" parent="."]
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="HurtBox"]
+modulate = Color( 0.286275, 0.764706, 1, 1 )
+shape = SubResource( 10 )
+
+[node name="BlockHitBox" type="Area2D" parent="."]
+monitorable = false
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="BlockHitBox"]
+position = Vector2( 0.8909, 29.6224 )
+shape = SubResource( 11 )
+
+[node name="BlockBox" type="Area2D" parent="."]
+monitorable = false
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="BlockBox"]
+position = Vector2( 0.445457, -31.4042 )
+shape = SubResource( 12 )
+
+[node name="KickHitBox" type="Area2D" parent="."]
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="KickHitBox"]
+modulate = Color( 0.94902, 0.356863, 0.356863, 1 )
+position = Vector2( 51.8948, 34.9678 )
+shape = SubResource( 13 )
+disabled = true
+
+[connection signal="area_entered" from="PunchHitBox" to="." method="_on_PunchHitBox_area_entered"]
+[connection signal="area_entered" from="KickHitBox" to="." method="_on_KickHitBox_area_entered"]

--- a/Main_Game.gd
+++ b/Main_Game.gd
@@ -1,0 +1,15 @@
+extends Node2D
+
+var characters
+var p1_start_pos = Vector2(300,480)
+var p2_start_pos = Vector2(700,480)
+
+func _ready() -> void:
+	characters = get_tree().get_nodes_in_group("Characters")
+	for c in characters:
+		if c.player_number == 1:
+			c.global_position = p1_start_pos
+		if c.player_number == 2:
+			c.global_position = p2_start_pos
+			c.scale.x = -1
+			c.facing_right = false

--- a/Main_Game.tscn
+++ b/Main_Game.tscn
@@ -1,8 +1,10 @@
-[gd_scene load_steps=2 format=2]
+[gd_scene load_steps=3 format=2]
 
+[ext_resource path="res://Main_Game.gd" type="Script" id=1]
 [ext_resource path="res://Fighter.tscn" type="PackedScene" id=2]
 
 [node name="Main_Game" type="Node2D"]
+script = ExtResource( 1 )
 
 [node name="SubZero" parent="." instance=ExtResource( 2 )]
 position = Vector2( 212.952, 479.937 )

--- a/project.godot
+++ b/project.godot
@@ -10,9 +10,13 @@ config_version=4
 
 [application]
 
-config/name="Template"
+config/name="SimpleFightingGame"
 run/main_scene="res://Main_Game.tscn"
 config/icon="res://icon.png"
+
+[debug]
+
+shapes/collision/shape_color=Color( 1, 1, 1, 0.419608 )
 
 [input]
 


### PR DESCRIPTION
Added hurtboxes and hitboxes for the character and the attacks. Right now, they just print a message when they connect, but I'm thinking sending signals to Main_Game.gd to handle that logic.

Left debug mode on so you can see the hitboxes, You can disable by going to Debug -> Visible Collision Shapes

Instead of doing `flip_h` on the sprites, I'm now doing `scale.x = -1`. I'm doing this because I manually cleaned up the animations so they look correct, but doing so makes them completely messed up when you flip the sprite. However, doing `scale.x = -1` then caused the RayCast2Ds to also flip, so my previous detection method no longer worked.

The new code for determining facing is in Main_Game.gd as I figured the characters themselves don't actually care about which way they are facing so it's probably better to handle that elsewhere.